### PR TITLE
Add type classes, laws, discipline

### DIFF
--- a/core/src/main/scala/litter/BoundedZeroSemilattice.scala
+++ b/core/src/main/scala/litter/BoundedZeroSemilattice.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litter
+
+import cats.kernel.BoundedSemilattice
+
+import scala.{specialized => sp}
+
+/**
+ * Bounded zero semilattices are bounded semilattices with an absorbing element that
+ * satisfies `combine(x, absorbing) == combine(absorbing, x) == absorbing`.
+ */
+trait BoundedZeroSemilattice[@sp(Int, Long, Float, Double) A]
+    extends Any
+    with BoundedSemilattice[A]
+    with ZeroSemilattice[A]
+    with CommutativeZeroMonoid[A]
+
+object BoundedZeroSemilattice extends ZeroSemilatticeFunctions[BoundedZeroSemilattice] {
+
+  /**
+   * Access an implicit `BoundedZeroSemilattice[A]`.
+   */
+  @inline final def apply[@sp(Int, Long, Float, Double) A](
+      implicit ev: BoundedZeroSemilattice[A]): BoundedZeroSemilattice[A] =
+    ev
+
+  /**
+   * Create a `BoundedZeroSemilattice` instance from the given function and empty and absorbing values.
+   */
+  @inline def instance[A](
+      emptyValue: A,
+      absorbingValue: A,
+      cmb: (A, A) => A): BoundedZeroSemilattice[A] =
+    new BoundedZeroSemilattice[A] {
+      override val empty: A = emptyValue
+      override val absorbing: A = absorbingValue
+
+      override def combine(x: A, y: A): A = cmb(x, y)
+    }
+}

--- a/core/src/main/scala/litter/CommutativeZeroGroup.scala
+++ b/core/src/main/scala/litter/CommutativeZeroGroup.scala
@@ -21,8 +21,8 @@ import cats.kernel.CommutativeGroup
 import scala.{specialized => sp}
 
 /**
- * An commutative zero group is a zero group
- * whose combine operation is commutative.
+ * A commutative zero group is a commutative group with an absorbing element
+ * that satisfies `combine(x, absorbing) == combine(absorbing, x) == absorbing`.
  */
 trait CommutativeZeroGroup[@sp(Int, Long, Float, Double) A]
     extends Any

--- a/core/src/main/scala/litter/CommutativeZeroGroup.scala
+++ b/core/src/main/scala/litter/CommutativeZeroGroup.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox
+
+import cats.kernel.CommutativeGroup
+
+import scala.{specialized => sp}
+
+/**
+ * An commutative zero group is a zero group
+ * whose combine operation is commutative.
+ */
+trait CommutativeZeroGroup[@sp(Int, Long, Float, Double) A]
+    extends Any
+    with ZeroGroup[A]
+    with CommutativeGroup[A]
+    with CommutativeZeroMonoid[A]
+
+object CommutativeZeroGroup extends ZeroGroupFunctions[CommutativeZeroGroup] {
+
+  /**
+   * Access an implicit `CommutativeZeroGroup[A]`.
+   */
+  @inline final def apply[A](implicit ev: CommutativeZeroGroup[A]): CommutativeZeroGroup[A] = ev
+}

--- a/core/src/main/scala/litter/CommutativeZeroGroup.scala
+++ b/core/src/main/scala/litter/CommutativeZeroGroup.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package litterbox
+package litter
 
 import cats.kernel.CommutativeGroup
 

--- a/core/src/main/scala/litter/CommutativeZeroMonoid.scala
+++ b/core/src/main/scala/litter/CommutativeZeroMonoid.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package litterbox
+package litter
 
 import cats.kernel.CommutativeMonoid
 

--- a/core/src/main/scala/litter/CommutativeZeroMonoid.scala
+++ b/core/src/main/scala/litter/CommutativeZeroMonoid.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox
+
+import cats.kernel.CommutativeMonoid
+
+import scala.{specialized => sp}
+
+/**
+ * CommutativeZeroMonoid represents a commutative zero monoid.
+ *
+ * A zero monoid is commutative if for all x and y, x |+| y === y |+| x.
+ */
+trait CommutativeZeroMonoid[@sp(Int, Long, Float, Double) A]
+    extends Any
+    with ZeroMonoid[A]
+    with CommutativeMonoid[A]
+    with CommutativeZeroSemigroup[A] { self =>
+  override def reverse: CommutativeZeroMonoid[A] = self
+}
+
+object CommutativeZeroMonoid extends ZeroMonoidFunctions[CommutativeZeroMonoid] {
+
+  /**
+   * Access an implicit `CommutativeZeroMonoid[A]`.
+   */
+  @inline final def apply[A](implicit ev: CommutativeZeroMonoid[A]): CommutativeMonoid[A] = ev
+
+  /**
+   * Create a `CommutativeZeroMonoid` instance from the given function and empty value.
+   */
+  @inline def instance[A](
+      emptyValue: A,
+      absorbingValue: A,
+      cmb: (A, A) => A): CommutativeMonoid[A] =
+    new CommutativeZeroMonoid[A] {
+      override val empty: A = emptyValue
+      override val absorbing: A = absorbingValue
+
+      override def combine(x: A, y: A): A = cmb(x, y)
+    }
+}

--- a/core/src/main/scala/litter/CommutativeZeroSemigroup.scala
+++ b/core/src/main/scala/litter/CommutativeZeroSemigroup.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox
+
+import cats.kernel.CommutativeSemigroup
+
+import scala.{specialized => sp}
+
+/**
+ * CommutativeZeroSemigroup represents a commutative zero semigroup.
+ *
+ * A zero semigroup is commutative if for all x and y, x |+| y === y |+| x.
+ */
+trait CommutativeZeroSemigroup[@sp(Int, Long, Float, Double) A]
+    extends Any
+    with ZeroSemigroup[A]
+    with CommutativeSemigroup[A] { self =>
+  override def reverse: CommutativeZeroSemigroup[A] = self
+  override def intercalate(middle: A): CommutativeZeroSemigroup[A] =
+    new CommutativeZeroSemigroup[A] {
+      override val absorbing: A = self.absorbing
+
+      def combine(a: A, b: A): A =
+        self.combine(a, self.combine(middle, b))
+
+      override def combineN(a: A, n: Int): A =
+        if (n <= 1) self.combineN(a, n)
+        else {
+          // a + m + a ... = combineN(a, n) + combineN(m, n - 1)
+          self.combine(self.combineN(a, n), self.combineN(middle, n - 1))
+        }
+    }
+}
+
+object CommutativeZeroSemigroup extends ZeroSemigroupFunctions[CommutativeZeroSemigroup] {
+
+  /**
+   * Access an implicit `CommutativeZeroSemigroup[A]`.
+   */
+  @inline final def apply[A](
+      implicit ev: CommutativeZeroSemigroup[A]): CommutativeZeroSemigroup[A] = ev
+
+  /**
+   * Create a `CommutativeZeroSemigroup` instance from the given absorbing value and function.
+   */
+  @inline def instance[A](absorbingValue: A, cmb: (A, A) => A): CommutativeZeroSemigroup[A] =
+    new CommutativeZeroSemigroup[A] {
+      override val absorbing: A = absorbingValue
+      override def combine(x: A, y: A): A = cmb(x, y)
+    }
+}

--- a/core/src/main/scala/litter/CommutativeZeroSemigroup.scala
+++ b/core/src/main/scala/litter/CommutativeZeroSemigroup.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package litterbox
+package litter
 
 import cats.kernel.CommutativeSemigroup
 

--- a/core/src/main/scala/litter/ZeroBand.scala
+++ b/core/src/main/scala/litter/ZeroBand.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litter
+
+import cats.kernel.Band
+
+import scala.{specialized => sp}
+
+/**
+ * Zero bands are bands with an absorbing element that satisfies
+ * `combine(x, absorbing) == combine(absorbing, x) == absorbing`.
+ */
+trait ZeroBand[@sp(Int, Long, Float, Double) A] extends Any with Band[A] with ZeroSemigroup[A]
+
+object ZeroBand extends ZeroSemigroupFunctions[ZeroBand] {
+
+  /**
+   * Access an implicit `ZeroBand[A]`.
+   */
+  @inline final def apply[@sp(Int, Long, Float, Double) A](
+      implicit ev: ZeroBand[A]): ZeroBand[A] = ev
+
+  /**
+   * Create a `ZeroBand` instance from the given function and absorbing value.
+   */
+  @inline def instance[A](absorbingValue: A, cmb: (A, A) => A): ZeroBand[A] =
+    new ZeroBand[A] {
+      override val absorbing: A = absorbingValue
+      override def combine(x: A, y: A): A = cmb(x, y)
+    }
+}

--- a/core/src/main/scala/litter/ZeroGroup.scala
+++ b/core/src/main/scala/litter/ZeroGroup.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package litterbox
+package litter
 
 import cats.kernel.Group
 

--- a/core/src/main/scala/litter/ZeroGroup.scala
+++ b/core/src/main/scala/litter/ZeroGroup.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox
+
+import cats.kernel.Group
+
+import scala.{specialized => sp}
+
+/**
+ * A group with an absorbing element.
+ */
+trait ZeroGroup[@sp(Int, Long, Float, Double) A] extends Any with Group[A] with ZeroMonoid[A]
+
+// TODO Extend from GroupFunctions when next version of Cats released
+trait ZeroGroupFunctions[G[T] <: ZeroGroup[T]] extends ZeroMonoidFunctions[G] {
+  def inverse[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: G[A]): A =
+    ev.inverse(a)
+
+  def remove[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: G[A]): A =
+    ev.remove(x, y)
+}
+
+object ZeroGroup extends ZeroGroupFunctions[ZeroGroup] {
+
+  /**
+   * Access an implicit `ZeroGroup[A]`.
+   */
+  @inline final def apply[A](implicit ev: ZeroGroup[A]): ZeroGroup[A] = ev
+}

--- a/core/src/main/scala/litter/ZeroMonoid.scala
+++ b/core/src/main/scala/litter/ZeroMonoid.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox
+
+import cats.kernel.{Monoid, MonoidFunctions}
+
+import scala.{specialized => sp}
+
+/**
+ * A monoid with an absorbing element.
+ */
+trait ZeroMonoid[@sp(Int, Long, Float, Double) A]
+    extends Any
+    with Monoid[A]
+    with ZeroSemigroup[A] { self =>
+  override def reverse: ZeroMonoid[A] =
+    new ZeroMonoid[A] {
+      override def empty: A = self.empty
+      override def absorbing: A = self.absorbing
+      override def combine(x: A, y: A): A = self.combine(y, x)
+    }
+}
+
+trait ZeroMonoidFunctions[M[T] <: ZeroMonoid[T]]
+    extends MonoidFunctions[M]
+    with ZeroSemigroupFunctions[M]
+
+object ZeroMonoid extends ZeroMonoidFunctions[ZeroMonoid] {
+
+  /**
+   * Access an implicit `ZeroMonoid[A]`.
+   */
+  @inline final def apply[A](implicit ev: ZeroMonoid[A]): ZeroMonoid[A] = ev
+
+  /**
+   * Create a `ZeroMonoid` instance from the given function and empty and absorbing values.
+   */
+  @inline def instance[A](emptyValue: A, absorbingValue: A, cmb: (A, A) => A): ZeroMonoid[A] =
+    new ZeroMonoid[A] {
+      override val empty: A = emptyValue
+      override val absorbing: A = absorbingValue
+
+      override def combine(x: A, y: A): A = cmb(x, y)
+    }
+}

--- a/core/src/main/scala/litter/ZeroMonoid.scala
+++ b/core/src/main/scala/litter/ZeroMonoid.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package litterbox
+package litter
 
 import cats.kernel.{Monoid, MonoidFunctions}
 

--- a/core/src/main/scala/litter/ZeroSemigroup.scala
+++ b/core/src/main/scala/litter/ZeroSemigroup.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package litterbox
+package litter
 
 import cats.kernel.{Eq, Semigroup, SemigroupFunctions}
 

--- a/core/src/main/scala/litter/ZeroSemigroup.scala
+++ b/core/src/main/scala/litter/ZeroSemigroup.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox
+
+import cats.kernel.{Eq, Semigroup, SemigroupFunctions}
+
+import scala.{specialized => sp}
+
+/**
+ * A zero semigroup is a semigroup with an absorbing element. A zero semigroup is a specialization of a
+ * semigroup, so its operation must be associative. Additionally,
+ * `combine(x, absorbing) == combine(absorbing, x) == absorbing`. For example, if we have `ZeroSemigroup[Int]`,
+ * with `combine` as integer multiplication, then `absorbing = 0`.
+ */
+trait ZeroSemigroup[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] { self =>
+
+  /**
+   * Return the absorbing element for this zero semigroup.
+   */
+  def absorbing: A
+
+  /**
+   * Tests if `a` is the absorbing element.
+   */
+  def isAbsorbing(a: A)(implicit ev: Eq[A]): Boolean =
+    ev.eqv(a, absorbing)
+
+  override def reverse: ZeroSemigroup[A] =
+    new ZeroSemigroup[A] {
+      override def absorbing: A = self.absorbing
+      override def combine(x: A, y: A): A = self.combine(y, x)
+      override def reverse: ZeroSemigroup[A] = self
+    }
+}
+
+trait ZeroSemigroupFunctions[S[T] <: ZeroSemigroup[T]] extends SemigroupFunctions[S] {
+  def absorbing[@sp(Int, Long, Float, Double) A](implicit ev: S[A]): A =
+    ev.absorbing
+
+  def isAbsorbing[@sp(Int, Long, Float, Double) A](a: A)(implicit s: S[A], ev: Eq[A]): Boolean =
+    s.isAbsorbing(a)
+}
+
+object ZeroSemigroup extends ZeroSemigroupFunctions[ZeroSemigroup] {
+
+  /**
+   * Access an implicit `ZeroSemigroup[A]`.
+   */
+  @inline final def apply[A](implicit ev: ZeroSemigroup[A]): ZeroSemigroup[A] = ev
+
+  /**
+   * Create a `ZeroSemigroup` instance from the given absorbing value and function.
+   */
+  @inline def instance[A](absorbingValue: A, cmb: (A, A) => A): ZeroSemigroup[A] =
+    new ZeroSemigroup[A] {
+      override val absorbing: A = absorbingValue
+      override def combine(x: A, y: A): A = cmb(x, y)
+    }
+}

--- a/core/src/main/scala/litter/ZeroSemigroup.scala
+++ b/core/src/main/scala/litter/ZeroSemigroup.scala
@@ -24,7 +24,7 @@ import scala.{specialized => sp}
  * A zero semigroup is a semigroup with an absorbing element. A zero semigroup is a specialization of a
  * semigroup, so its operation must be associative. Additionally,
  * `combine(x, absorbing) == combine(absorbing, x) == absorbing`. For example, if we have `ZeroSemigroup[Int]`,
- * with `combine` as integer multiplication, then `absorbing = 0`.
+ * with `combine` as integer multiplication, then `absorbing == 0`.
  */
 trait ZeroSemigroup[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] { self =>
 

--- a/core/src/main/scala/litter/ZeroSemilattice.scala
+++ b/core/src/main/scala/litter/ZeroSemilattice.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litter
+
+import cats.kernel.{Semilattice, SemilatticeFunctions}
+
+import scala.{specialized => sp}
+
+/**
+ * Zero semilattices are semilattices with an absorbing element that
+ * satisfies `combine(x, absorbing) == combine(absorbing, x) == absorbing`.
+ */
+trait ZeroSemilattice[@sp(Int, Long, Float, Double) A]
+    extends Any
+    with Semilattice[A]
+    with ZeroBand[A]
+    with CommutativeZeroSemigroup[A]
+
+trait ZeroSemilatticeFunctions[S[T] <: ZeroSemilattice[T]]
+    extends SemilatticeFunctions[S]
+    with ZeroSemigroupFunctions[S]
+
+object ZeroSemilattice extends ZeroSemilatticeFunctions[ZeroSemilattice] {
+
+  /**
+   * Access an implicit `ZeroSemilattice[A]`.
+   */
+  @inline final def apply[@sp(Int, Long, Float, Double) A](
+      implicit ev: Semilattice[A]): Semilattice[A] = ev
+
+  /**
+   * Create a `ZeroSemilattice` instance from the given function and absorbing value.
+   */
+  @inline def instance[A](absorbingValue: A, cmb: (A, A) => A): ZeroSemilattice[A] =
+    new ZeroSemilattice[A] {
+      override val absorbing: A = absorbingValue
+      override def combine(x: A, y: A): A = cmb(x, y)
+    }
+}

--- a/laws/src/main/scala/litter/laws/BoundedZeroSemilatticeLaws.scala
+++ b/laws/src/main/scala/litter/laws/BoundedZeroSemilatticeLaws.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litter.laws
+
+import cats.kernel.laws.BoundedSemilatticeLaws
+import litter.BoundedZeroSemilattice
+
+trait BoundedZeroSemilatticeLaws[A]
+    extends BoundedSemilatticeLaws[A]
+    with ZeroSemilatticeLaws[A]
+    with CommutativeZeroMonoidLaws[A] {
+  implicit override def S: BoundedZeroSemilattice[A]
+}
+
+object BoundedZeroSemilatticeLaws {
+  def apply[A](implicit ev: BoundedZeroSemilattice[A]): BoundedZeroSemilatticeLaws[A] =
+    new BoundedZeroSemilatticeLaws[A] { def S: BoundedZeroSemilattice[A] = ev }
+}

--- a/laws/src/main/scala/litter/laws/CommutativeZeroGroupLaws.scala
+++ b/laws/src/main/scala/litter/laws/CommutativeZeroGroupLaws.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws
+
+import cats.kernel.laws.CommutativeGroupLaws
+import litterbox.CommutativeZeroGroup
+
+trait CommutativeZeroGroupLaws[A]
+    extends CommutativeGroupLaws[A]
+    with ZeroGroupLaws[A]
+    with CommutativeZeroMonoidLaws[A] {
+  implicit override def S: CommutativeZeroGroup[A]
+}
+
+object CommutativeZeroGroupLaws {
+  def apply[A](implicit ev: CommutativeZeroGroup[A]): CommutativeZeroGroupLaws[A] =
+    new CommutativeZeroGroupLaws[A] { def S: CommutativeZeroGroup[A] = ev }
+}

--- a/laws/src/main/scala/litter/laws/CommutativeZeroGroupLaws.scala
+++ b/laws/src/main/scala/litter/laws/CommutativeZeroGroupLaws.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package litterbox.laws
+package litter.laws
 
 import cats.kernel.laws.CommutativeGroupLaws
-import litterbox.CommutativeZeroGroup
+import litter.CommutativeZeroGroup
 
 trait CommutativeZeroGroupLaws[A]
     extends CommutativeGroupLaws[A]

--- a/laws/src/main/scala/litter/laws/CommutativeZeroMonoidLaws.scala
+++ b/laws/src/main/scala/litter/laws/CommutativeZeroMonoidLaws.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package litterbox.laws
+package litter.laws
 
 import cats.kernel.laws.CommutativeMonoidLaws
-import litterbox.CommutativeZeroMonoid
+import litter.CommutativeZeroMonoid
 
 trait CommutativeZeroMonoidLaws[A]
     extends CommutativeMonoidLaws[A]

--- a/laws/src/main/scala/litter/laws/CommutativeZeroMonoidLaws.scala
+++ b/laws/src/main/scala/litter/laws/CommutativeZeroMonoidLaws.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws
+
+import cats.kernel.laws.CommutativeMonoidLaws
+import litterbox.CommutativeZeroMonoid
+
+trait CommutativeZeroMonoidLaws[A]
+    extends CommutativeMonoidLaws[A]
+    with CommutativeZeroSemigroupLaws[A]
+    with ZeroMonoidLaws[A] {
+  implicit override def S: CommutativeZeroMonoid[A]
+}
+
+object CommutativeZeroMonoidLaws {
+  def apply[A](implicit ev: CommutativeZeroMonoid[A]): CommutativeZeroMonoidLaws[A] =
+    new CommutativeZeroMonoidLaws[A] { def S: CommutativeZeroMonoid[A] = ev }
+}

--- a/laws/src/main/scala/litter/laws/CommutativeZeroSemigroupLaws.scala
+++ b/laws/src/main/scala/litter/laws/CommutativeZeroSemigroupLaws.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws
+
+import cats.kernel.laws.CommutativeSemigroupLaws
+import litterbox.CommutativeZeroSemigroup
+
+trait CommutativeZeroSemigroupLaws[A]
+    extends CommutativeSemigroupLaws[A]
+    with ZeroSemigroupLaws[A] {
+  implicit override def S: CommutativeZeroSemigroup[A]
+}
+
+object CommutativeZeroSemigroupLaws {
+  def apply[A](implicit ev: CommutativeZeroSemigroup[A]): CommutativeZeroSemigroupLaws[A] =
+    new CommutativeZeroSemigroupLaws[A] { def S: CommutativeZeroSemigroup[A] = ev }
+}

--- a/laws/src/main/scala/litter/laws/CommutativeZeroSemigroupLaws.scala
+++ b/laws/src/main/scala/litter/laws/CommutativeZeroSemigroupLaws.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package litterbox.laws
+package litter.laws
 
 import cats.kernel.laws.CommutativeSemigroupLaws
-import litterbox.CommutativeZeroSemigroup
+import litter.CommutativeZeroSemigroup
 
 trait CommutativeZeroSemigroupLaws[A]
     extends CommutativeSemigroupLaws[A]

--- a/laws/src/main/scala/litter/laws/ZeroBandLaws.scala
+++ b/laws/src/main/scala/litter/laws/ZeroBandLaws.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litter.laws
+
+import cats.kernel.laws.BandLaws
+import litter.ZeroBand
+
+trait ZeroBandLaws[A] extends BandLaws[A] with ZeroSemigroupLaws[A] {
+  implicit override def S: ZeroBand[A]
+}
+
+object ZeroBandLaws {
+  def apply[A](implicit ev: ZeroBand[A]): ZeroBandLaws[A] =
+    new ZeroBandLaws[A] { def S: ZeroBand[A] = ev }
+}

--- a/laws/src/main/scala/litter/laws/ZeroGroupLaws.scala
+++ b/laws/src/main/scala/litter/laws/ZeroGroupLaws.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws
+
+import cats.kernel.laws.GroupLaws
+import litterbox.ZeroGroup
+
+trait ZeroGroupLaws[A] extends GroupLaws[A] with ZeroMonoidLaws[A] {
+  implicit override def S: ZeroGroup[A]
+}
+
+object ZeroGroupLaws {
+  def apply[A](implicit ev: ZeroGroup[A]): ZeroGroupLaws[A] =
+    new ZeroGroupLaws[A] { def S: ZeroGroup[A] = ev }
+}

--- a/laws/src/main/scala/litter/laws/ZeroGroupLaws.scala
+++ b/laws/src/main/scala/litter/laws/ZeroGroupLaws.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package litterbox.laws
+package litter.laws
 
 import cats.kernel.laws.GroupLaws
-import litterbox.ZeroGroup
+import litter.ZeroGroup
 
 trait ZeroGroupLaws[A] extends GroupLaws[A] with ZeroMonoidLaws[A] {
   implicit override def S: ZeroGroup[A]

--- a/laws/src/main/scala/litter/laws/ZeroMonoidLaws.scala
+++ b/laws/src/main/scala/litter/laws/ZeroMonoidLaws.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws
+
+import cats.kernel.laws.MonoidLaws
+import litterbox.ZeroMonoid
+
+trait ZeroMonoidLaws[A] extends MonoidLaws[A] with ZeroSemigroupLaws[A] {
+  implicit override def S: ZeroMonoid[A]
+}
+
+object ZeroMonoidLaws {
+  def apply[A](implicit ev: ZeroMonoid[A]): ZeroMonoidLaws[A] =
+    new ZeroMonoidLaws[A] { def S: ZeroMonoid[A] = ev }
+}

--- a/laws/src/main/scala/litter/laws/ZeroMonoidLaws.scala
+++ b/laws/src/main/scala/litter/laws/ZeroMonoidLaws.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package litterbox.laws
+package litter.laws
 
 import cats.kernel.laws.MonoidLaws
-import litterbox.ZeroMonoid
+import litter.ZeroMonoid
 
 trait ZeroMonoidLaws[A] extends MonoidLaws[A] with ZeroSemigroupLaws[A] {
   implicit override def S: ZeroMonoid[A]

--- a/laws/src/main/scala/litter/laws/ZeroSemigroupLaws.scala
+++ b/laws/src/main/scala/litter/laws/ZeroSemigroupLaws.scala
@@ -23,10 +23,10 @@ import litter.ZeroSemigroup
 trait ZeroSemigroupLaws[A] extends SemigroupLaws[A] {
   implicit override def S: ZeroSemigroup[A]
 
-  def leftAbsorbtion(x: A): IsEq[A] =
+  def leftAbsorption(x: A): IsEq[A] =
     S.combine(S.absorbing, x) <-> x
 
-  def rightAbsorbtion(x: A): IsEq[A] =
+  def rightAbsorption(x: A): IsEq[A] =
     S.combine(x, S.absorbing) <-> x
 
   def isAbsorbing(x: A, eqv: Eq[A]): IsEq[Boolean] =

--- a/laws/src/main/scala/litter/laws/ZeroSemigroupLaws.scala
+++ b/laws/src/main/scala/litter/laws/ZeroSemigroupLaws.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package litterbox.laws
+package litter.laws
 
 import cats.kernel.Eq
 import cats.kernel.laws.{IsEq, IsEqArrow, SemigroupLaws}
-import litterbox.ZeroSemigroup
+import litter.ZeroSemigroup
 
 trait ZeroSemigroupLaws[A] extends SemigroupLaws[A] {
   implicit override def S: ZeroSemigroup[A]

--- a/laws/src/main/scala/litter/laws/ZeroSemigroupLaws.scala
+++ b/laws/src/main/scala/litter/laws/ZeroSemigroupLaws.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws
+
+import cats.kernel.Eq
+import cats.kernel.laws.{IsEq, IsEqArrow, SemigroupLaws}
+import litterbox.ZeroSemigroup
+
+trait ZeroSemigroupLaws[A] extends SemigroupLaws[A] {
+  implicit override def S: ZeroSemigroup[A]
+
+  def leftAbsorbtion(x: A): IsEq[A] =
+    S.combine(S.absorbing, x) <-> x
+
+  def rightAbsorbtion(x: A): IsEq[A] =
+    S.combine(x, S.absorbing) <-> x
+
+  def isAbsorbing(x: A, eqv: Eq[A]): IsEq[Boolean] =
+    eqv.eqv(x, S.absorbing) <-> S.isAbsorbing(x)(eqv)
+
+}
+
+object ZeroSemigroupLaws {
+  def apply[A](implicit ev: ZeroSemigroup[A]): ZeroSemigroupLaws[A] =
+    new ZeroSemigroupLaws[A] { def S: ZeroSemigroup[A] = ev }
+}

--- a/laws/src/main/scala/litter/laws/ZeroSemigroupLaws.scala
+++ b/laws/src/main/scala/litter/laws/ZeroSemigroupLaws.scala
@@ -24,10 +24,10 @@ trait ZeroSemigroupLaws[A] extends SemigroupLaws[A] {
   implicit override def S: ZeroSemigroup[A]
 
   def leftAbsorption(x: A): IsEq[A] =
-    S.combine(S.absorbing, x) <-> x
+    S.combine(S.absorbing, x) <-> S.absorbing
 
   def rightAbsorption(x: A): IsEq[A] =
-    S.combine(x, S.absorbing) <-> x
+    S.combine(x, S.absorbing) <-> S.absorbing
 
   def isAbsorbing(x: A, eqv: Eq[A]): IsEq[Boolean] =
     eqv.eqv(x, S.absorbing) <-> S.isAbsorbing(x)(eqv)

--- a/laws/src/main/scala/litter/laws/ZeroSemilatticeLaws.scala
+++ b/laws/src/main/scala/litter/laws/ZeroSemilatticeLaws.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litter.laws
+
+import cats.kernel.laws.SemilatticeLaws
+import litter.ZeroSemilattice
+
+trait ZeroSemilatticeLaws[A]
+    extends SemilatticeLaws[A]
+    with ZeroBandLaws[A]
+    with CommutativeZeroSemigroupLaws[A] {
+  implicit override def S: ZeroSemilattice[A]
+}
+
+object ZeroSemilatticeLaws {
+  def apply[A](implicit ev: ZeroSemilattice[A]): ZeroSemilatticeLaws[A] =
+    new ZeroSemilatticeLaws[A] { def S: ZeroSemilattice[A] = ev }
+}

--- a/laws/src/main/scala/litter/laws/discipline/BoundedZeroSemilatticeTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/BoundedZeroSemilatticeTests.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litter.laws.discipline
+
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.BoundedSemilatticeTests
+import litter.BoundedZeroSemilattice
+import litter.laws.BoundedZeroSemilatticeLaws
+import org.scalacheck.{Arbitrary, Prop}
+
+trait BoundedZeroSemilatticeTests[A]
+    extends BoundedSemilatticeTests[A]
+    with ZeroSemilatticeTests[A]
+    with CommutativeZeroMonoidTests[A] {
+  def laws: BoundedZeroSemilatticeLaws[A]
+
+  def boundedZeroSemilattice(implicit arbA: Arbitrary[A], eqA: Eq[A]): RuleSet =
+    new RuleSet {
+      val name: String = "BoundedZeroSemilattice"
+      val bases: Seq[(String, RuleSet)] = Nil
+      val parents: Seq[RuleSet] =
+        Seq(boundedSemilattice, zeroSemilattice, commutativeZeroMonoid)
+      val props: Seq[(String, Prop)] = Nil
+    }
+
+}
+
+object BoundedZeroSemilatticeTests {
+  def apply[A: BoundedZeroSemilattice]: BoundedZeroSemilatticeTests[A] =
+    new BoundedZeroSemilatticeTests[A] {
+      def laws: BoundedZeroSemilatticeLaws[A] = BoundedZeroSemilatticeLaws[A]
+    }
+}

--- a/laws/src/main/scala/litter/laws/discipline/CommutativeZeroGroupTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/CommutativeZeroGroupTests.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws.discipline
+
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.CommutativeGroupTests
+import litterbox.CommutativeZeroGroup
+import litterbox.laws.CommutativeZeroGroupLaws
+import org.scalacheck.{Arbitrary, Prop}
+
+trait CommutativeZeroGroupTests[A]
+    extends CommutativeGroupTests[A]
+    with ZeroGroupTests[A]
+    with CommutativeZeroMonoidTests[A] {
+  def laws: CommutativeZeroGroupLaws[A]
+
+  def commutativeZeroGroup(implicit arbA: Arbitrary[A], eqA: Eq[A]): RuleSet =
+    new RuleSet {
+      val name: String = "zeroMonoid"
+      val bases: Seq[(String, RuleSet)] = Nil
+      val parents: Seq[RuleSet] = Seq(commutativeGroup, zeroGroup, commutativeZeroGroup)
+      val props: Seq[(String, Prop)] = Nil
+    }
+
+}
+
+object CommutativeZeroGroupTests {
+  def apply[A: CommutativeZeroGroup]: CommutativeZeroGroupTests[A] =
+    new CommutativeZeroGroupTests[A] {
+      def laws: CommutativeZeroGroupLaws[A] = CommutativeZeroGroupLaws[A]
+    }
+}

--- a/laws/src/main/scala/litter/laws/discipline/CommutativeZeroGroupTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/CommutativeZeroGroupTests.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package litterbox.laws.discipline
+package litter.laws.discipline
 
 import cats.kernel.Eq
 import cats.kernel.laws.discipline.CommutativeGroupTests
-import litterbox.CommutativeZeroGroup
-import litterbox.laws.CommutativeZeroGroupLaws
+import litter.CommutativeZeroGroup
+import litter.laws.CommutativeZeroGroupLaws
 import org.scalacheck.{Arbitrary, Prop}
 
 trait CommutativeZeroGroupTests[A]

--- a/laws/src/main/scala/litter/laws/discipline/CommutativeZeroMonoidTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/CommutativeZeroMonoidTests.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws.discipline
+
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.CommutativeMonoidTests
+import litterbox.CommutativeZeroMonoid
+import litterbox.laws.CommutativeZeroMonoidLaws
+import org.scalacheck.{Arbitrary, Prop}
+
+trait CommutativeZeroMonoidTests[A]
+    extends CommutativeMonoidTests[A]
+    with ZeroMonoidTests[A]
+    with CommutativeZeroSemigroupTests[A] {
+  def laws: CommutativeZeroMonoidLaws[A]
+
+  def commutativeZeroMonoid(implicit arbA: Arbitrary[A], eqA: Eq[A]): RuleSet =
+    new RuleSet {
+      val name: String = "zeroMonoid"
+      val bases: Seq[(String, RuleSet)] = Nil
+      val parents: Seq[RuleSet] = Seq(commutativeMonoid, zeroMonoid, commutativeZeroSemigroup)
+      val props: Seq[(String, Prop)] = Nil
+    }
+
+}
+
+object CommutativeZeroMonoidTests {
+  def apply[A: CommutativeZeroMonoid]: CommutativeZeroMonoidTests[A] =
+    new CommutativeZeroMonoidTests[A] {
+      def laws: CommutativeZeroMonoidLaws[A] = CommutativeZeroMonoidLaws[A]
+    }
+}

--- a/laws/src/main/scala/litter/laws/discipline/CommutativeZeroMonoidTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/CommutativeZeroMonoidTests.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package litterbox.laws.discipline
+package litter.laws.discipline
 
 import cats.kernel.Eq
 import cats.kernel.laws.discipline.CommutativeMonoidTests
-import litterbox.CommutativeZeroMonoid
-import litterbox.laws.CommutativeZeroMonoidLaws
+import litter.CommutativeZeroMonoid
+import litter.laws.CommutativeZeroMonoidLaws
 import org.scalacheck.{Arbitrary, Prop}
 
 trait CommutativeZeroMonoidTests[A]

--- a/laws/src/main/scala/litter/laws/discipline/CommutativeZeroSemigroupTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/CommutativeZeroSemigroupTests.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package litterbox.laws.discipline
+package litter.laws.discipline
 
 import cats.kernel.Eq
 import cats.kernel.laws.discipline.CommutativeSemigroupTests
-import litterbox.CommutativeZeroSemigroup
-import litterbox.laws.CommutativeZeroSemigroupLaws
+import litter.CommutativeZeroSemigroup
+import litter.laws.CommutativeZeroSemigroupLaws
 import org.scalacheck.{Arbitrary, Prop}
 
 trait CommutativeZeroSemigroupTests[A]

--- a/laws/src/main/scala/litter/laws/discipline/CommutativeZeroSemigroupTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/CommutativeZeroSemigroupTests.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws.discipline
+
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.CommutativeSemigroupTests
+import litterbox.CommutativeZeroSemigroup
+import litterbox.laws.CommutativeZeroSemigroupLaws
+import org.scalacheck.{Arbitrary, Prop}
+
+trait CommutativeZeroSemigroupTests[A]
+    extends CommutativeSemigroupTests[A]
+    with ZeroSemigroupTests[A] {
+  def laws: CommutativeZeroSemigroupLaws[A]
+
+  def commutativeZeroSemigroup(implicit arbA: Arbitrary[A], eqA: Eq[A]): RuleSet =
+    new RuleSet {
+      val name: String = "commutativeZeroSemigroup"
+      val bases: Seq[(String, RuleSet)] = Nil
+      val parents: Seq[RuleSet] = Seq(commutativeSemigroup, zeroSemigroup)
+      val props: Seq[(String, Prop)] = Nil
+    }
+
+}
+
+object CommutativeZeroSemigroupTests {
+  def apply[A: CommutativeZeroSemigroup]: CommutativeZeroSemigroupTests[A] =
+    new CommutativeZeroSemigroupTests[A] {
+      def laws: CommutativeZeroSemigroupLaws[A] = CommutativeZeroSemigroupLaws[A]
+    }
+}

--- a/laws/src/main/scala/litter/laws/discipline/ZeroBandTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/ZeroBandTests.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litter.laws.discipline
+
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.BandTests
+import litter.ZeroBand
+import litter.laws.ZeroBandLaws
+import org.scalacheck.{Arbitrary, Prop}
+
+trait ZeroBandTests[A] extends BandTests[A] with ZeroSemigroupTests[A] {
+  def laws: ZeroBandLaws[A]
+
+  def zeroBand(implicit arbA: Arbitrary[A], eqA: Eq[A]): RuleSet =
+    new RuleSet {
+      val name: String = "ZeroBand"
+      val bases: Seq[(String, RuleSet)] = Nil
+      val parents: Seq[RuleSet] = Seq(band, zeroSemigroup)
+      val props: Seq[(String, Prop)] = Nil
+    }
+
+}
+
+object ZeroBandTests {
+  def apply[A: ZeroBand]: ZeroBandTests[A] =
+    new ZeroBandTests[A] { def laws: ZeroBandLaws[A] = ZeroBandLaws[A] }
+}

--- a/laws/src/main/scala/litter/laws/discipline/ZeroGroupTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/ZeroGroupTests.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws.discipline
+
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.GroupTests
+import litterbox.ZeroGroup
+import litterbox.laws.ZeroGroupLaws
+import org.scalacheck.{Arbitrary, Prop}
+
+trait ZeroGroupTests[A] extends GroupTests[A] with ZeroMonoidTests[A] {
+  def laws: ZeroGroupLaws[A]
+
+  def zeroGroup(implicit arbA: Arbitrary[A], eqA: Eq[A]): RuleSet =
+    new RuleSet {
+      val name: String = "zeroGroup"
+      val bases: Seq[(String, RuleSet)] = Nil
+      val parents: Seq[RuleSet] = Seq(group, zeroMonoid)
+      val props: Seq[(String, Prop)] = Nil
+    }
+
+}
+
+object ZeroGroupTests {
+  def apply[A: ZeroGroup]: ZeroGroupTests[A] =
+    new ZeroGroupTests[A] { def laws: ZeroGroupLaws[A] = ZeroGroupLaws[A] }
+}

--- a/laws/src/main/scala/litter/laws/discipline/ZeroGroupTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/ZeroGroupTests.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package litterbox.laws.discipline
+package litter.laws.discipline
 
 import cats.kernel.Eq
 import cats.kernel.laws.discipline.GroupTests
-import litterbox.ZeroGroup
-import litterbox.laws.ZeroGroupLaws
+import litter.ZeroGroup
+import litter.laws.ZeroGroupLaws
 import org.scalacheck.{Arbitrary, Prop}
 
 trait ZeroGroupTests[A] extends GroupTests[A] with ZeroMonoidTests[A] {

--- a/laws/src/main/scala/litter/laws/discipline/ZeroMonoidTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/ZeroMonoidTests.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package litterbox.laws.discipline
+package litter.laws.discipline
 
 import cats.kernel.Eq
 import cats.kernel.laws.discipline.MonoidTests
-import litterbox.ZeroMonoid
-import litterbox.laws.ZeroMonoidLaws
+import litter.ZeroMonoid
+import litter.laws.ZeroMonoidLaws
 import org.scalacheck.{Arbitrary, Prop}
 
 trait ZeroMonoidTests[A] extends MonoidTests[A] with ZeroSemigroupTests[A] {

--- a/laws/src/main/scala/litter/laws/discipline/ZeroMonoidTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/ZeroMonoidTests.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws.discipline
+
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.MonoidTests
+import litterbox.ZeroMonoid
+import litterbox.laws.ZeroMonoidLaws
+import org.scalacheck.{Arbitrary, Prop}
+
+trait ZeroMonoidTests[A] extends MonoidTests[A] with ZeroSemigroupTests[A] {
+  def laws: ZeroMonoidLaws[A]
+
+  def zeroMonoid(implicit arbA: Arbitrary[A], eqA: Eq[A]): RuleSet =
+    new RuleSet {
+      val name: String = "zeroMonoid"
+      val bases: Seq[(String, RuleSet)] = Nil
+      val parents: Seq[RuleSet] = Seq(monoid, zeroSemigroup)
+      val props: Seq[(String, Prop)] = Nil
+    }
+
+}
+
+object ZeroMonoidTests {
+  def apply[A: ZeroMonoid]: ZeroMonoidTests[A] =
+    new ZeroMonoidTests[A] { def laws: ZeroMonoidLaws[A] = ZeroMonoidLaws[A] }
+}

--- a/laws/src/main/scala/litter/laws/discipline/ZeroSemigroupTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/ZeroSemigroupTests.scala
@@ -31,8 +31,8 @@ trait ZeroSemigroupTests[A] extends SemigroupTests[A] {
     new DefaultRuleSet(
       "zeroSemigroup",
       Some(semigroup),
-      "left absorbtion" -> forAll(laws.leftAbsorbtion _),
-      "right absorbtion" -> forAll(laws.rightAbsorbtion _),
+      "left absorption" -> forAll(laws.leftAbsorption _),
+      "right absorption" -> forAll(laws.rightAbsorption _),
       "isAbsorbing" -> forAll((a: A) => laws.isAbsorbing(a, eqA))
     )
 }

--- a/laws/src/main/scala/litter/laws/discipline/ZeroSemigroupTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/ZeroSemigroupTests.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litterbox.laws.discipline
+
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.{SemigroupTests, _}
+import litterbox.ZeroSemigroup
+import litterbox.laws.ZeroSemigroupLaws
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop.forAll
+
+trait ZeroSemigroupTests[A] extends SemigroupTests[A] {
+
+  def laws: ZeroSemigroupLaws[A]
+
+  def zeroSemigroup(implicit arbA: Arbitrary[A], eqA: Eq[A]): RuleSet =
+    new DefaultRuleSet(
+      "zeroSemigroup",
+      Some(semigroup),
+      "left absorbtion" -> forAll(laws.leftAbsorbtion _),
+      "right absorbtion" -> forAll(laws.rightAbsorbtion _),
+      "isAbsorbing" -> forAll((a: A) => laws.isAbsorbing(a, eqA))
+    )
+}
+
+object ZeroSemigroupTests {
+  def apply[A: ZeroSemigroup]: ZeroSemigroupTests[A] =
+    new ZeroSemigroupTests[A] { def laws: ZeroSemigroupLaws[A] = ZeroSemigroupLaws[A] }
+}

--- a/laws/src/main/scala/litter/laws/discipline/ZeroSemigroupTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/ZeroSemigroupTests.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package litterbox.laws.discipline
+package litter.laws.discipline
 
 import cats.kernel.Eq
 import cats.kernel.laws.discipline.{SemigroupTests, _}
-import litterbox.ZeroSemigroup
-import litterbox.laws.ZeroSemigroupLaws
+import litter.ZeroSemigroup
+import litter.laws.ZeroSemigroupLaws
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll
 

--- a/laws/src/main/scala/litter/laws/discipline/ZeroSemilatticeTests.scala
+++ b/laws/src/main/scala/litter/laws/discipline/ZeroSemilatticeTests.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package litter.laws.discipline
+
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.SemilatticeTests
+import litter.ZeroSemilattice
+import litter.laws.ZeroSemilatticeLaws
+import org.scalacheck.{Arbitrary, Prop}
+
+trait ZeroSemilatticeTests[A]
+    extends SemilatticeTests[A]
+    with ZeroBandTests[A]
+    with CommutativeZeroSemigroupTests[A] {
+  def laws: ZeroSemilatticeLaws[A]
+
+  def zeroSemilattice(implicit arbA: Arbitrary[A], eqA: Eq[A]): RuleSet =
+    new RuleSet {
+      val name: String = "ZeroSemilattice"
+      val bases: Seq[(String, RuleSet)] = Nil
+      val parents: Seq[RuleSet] = Seq(semilattice, zeroBand, commutativeZeroSemigroup)
+      val props: Seq[(String, Prop)] = Nil
+    }
+
+}
+
+object ZeroSemilatticeTests {
+  def apply[A: ZeroSemilattice]: ZeroSemilatticeTests[A] =
+    new ZeroSemilatticeTests[A] { def laws: ZeroSemilatticeLaws[A] = ZeroSemilatticeLaws[A] }
+}


### PR DESCRIPTION
Implements `ZeroSemigroup`, `CommutativeZeroSemigroup`, `ZeroMonoid`, `CommutativeZeroMonoid`, `ZeroGroup`, and `CommutativeZeroGroup` and their laws/discipline. I decided to pass on further refinement to left/right zeros (besides, Cats doesn't distinguish between left/right `empty`).